### PR TITLE
Add README content and other project files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Use unix line endings everywhere, even on Windows
+* text=auto eol=lf

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 pnpm-lock.yaml
 tsp-output/
+dist/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,41 @@
+# Contributing to TypeSpec MCP
+
+There are many ways to contribute to the TypeSpec MCP project: reporting bugs, submitting pull requests, and creating suggestions.
+
+>[!IMPORTANT]
+If you are contributing significant changes, or if the issue is already assigned to a specific milestone, please discuss with the assignee of the issue first before starting to work on the issue.
+
+## Prerequisites
+
+1. Install either the stable or Insiders release of VS Code.
+   * [Stable release](https://code.visualstudio.com/download)
+   * [Insiders release](https://code.visualstudio.com/insiders)
+2. Install [GitHub Copilot](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot) and [GitHub Copilot Chat](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot-chat) extensions.
+3. Install [Node.js](https://nodejs.org/en/download) 22 or later
+   * Ensure `node` and `npm` are in your path
+
+## Development Process
+
+1. Fork the repository
+2. Create a feature branch
+3. Make your changes
+4. Write or update tests
+5. Submit a pull request
+
+## Questions and Support
+
+- Create an issue for questions
+- Tag @xirzec for specific help or clarification
+
+## Additional Resources
+
+- [VS Code Insiders Download](https://code.visualstudio.com/insiders/)
+- [GitHub Copilot Documentation](https://docs.github.com/en/copilot)
+
+## Code of Conduct
+
+This project adheres to a standard code of conduct. By participating, you are expected to uphold this code.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the project's license.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,17 +2,17 @@
 
 There are many ways to contribute to the TypeSpec MCP project: reporting bugs, submitting pull requests, and creating suggestions.
 
->[!IMPORTANT]
-If you are contributing significant changes, or if the issue is already assigned to a specific milestone, please discuss with the assignee of the issue first before starting to work on the issue.
+> [!IMPORTANT]
+> If you are contributing significant changes, or if the issue is already assigned to a specific milestone, please discuss with the assignee of the issue first before starting to work on the issue.
 
 ## Prerequisites
 
 1. Install either the stable or Insiders release of VS Code.
-   * [Stable release](https://code.visualstudio.com/download)
-   * [Insiders release](https://code.visualstudio.com/insiders)
+   - [Stable release](https://code.visualstudio.com/download)
+   - [Insiders release](https://code.visualstudio.com/insiders)
 2. Install [GitHub Copilot](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot) and [GitHub Copilot Chat](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot-chat) extensions.
-3. Install [Node.js](https://nodejs.org/en/download) 22 or later
-   * Ensure `node` and `npm` are in your path
+3. Install [Node.js](https://nodejs.org/en/download) 20 or later
+   - Ensure `node` and `npm` are in your path
 
 ## Development Process
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright 2025 (c) Microsoft Corporation.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Currently this repo contains the following packages:
 
 ## Currently Supported Tools
 
-The Azure MCP Server provides tools for interacting with the following Azure services:
+The TypeSpec MCP Server provides the following tools:
 
 - `learnTypeSpec` - Initializes the model with information about how to understand and write TypeSpec.
 - `init` - Scaffolds out a new project in the current working directory with example tool implementation.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,101 @@
+# TypeSpec MCP Server and Emitter
+
+[![Install with NPX in VS Code](https://img.shields.io/badge/VS_Code-Install_TypeSpec_MCP_Server-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=TypeSpec%20MCP%20Server&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22mcp-server-typespec%40latest%22%5D%7D) [![Install with NPX in VS Code Insiders](https://img.shields.io/badge/VS_Code_Insiders-Install_TypeSpec_MCP_Server-24bfa5?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=TypeSpec%20MCP%20Server&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22mcp-server-typespec%40latest%22%5D%7D&quality=insiders)
+
+The TypeSpec MCP Server implements the [MCP specification](https://modelcontextprotocol.io) to enable you to quickly build out your own MCP extensions powered by [TypeSpec](https://typespec.io/)
+
+> Please note that this project is in Public Preview and implementation may significantly change prior to our General Availability.
+
+## Overview
+
+### What packages are in this repository?
+
+Currently this repo contains the following packages:
+
+- [mcp-server-typespec](https://github.com/bterlson/typespec-mcp/tree/main/packages/mcp-server-typespec) - an MCP server which assists in developing MCP extensions using TypeSpec.
+- [typespec-mcp](https://github.com/bterlson/typespec-mcp/tree/main/packages/typespec-mcp) - a TypeSpec library that provides a `tool` decorator.
+- [typespec-mcp-server-js](https://github.com/bterlson/typespec-mcp/tree/main/packages/typespec-mcp-server-js) - A TypeSpec emitter that generates a server implementation in JavaScript for an MCP tool.
+- [typespec-mcp-http-server-js](https://github.com/bterlson/typespec-mcp/tree/main/packages/typespec-mcp-http-server-js) - A TypeSpec emitter that generates a server implementation in JavaScript for calling a remote REST API.
+
+## Currently Supported Tools
+
+The Azure MCP Server provides tools for interacting with the following Azure services:
+
+- `learnTypeSpec` - Initializes the model with information about how to understand and write TypeSpec.
+- `init` - Scaffolds out a new project in the current working directory with example tool implementation.
+- `compile` - Runs tsp compile to generate emitter assets
+- `build` - Executes `npm run build` in the current project.
+
+
+## Getting Started
+
+The TypeSpec MCP Server requires Node.js to install and run the server. If you don't have it installed, follow the instructions [here](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm).
+
+### VS Code + GitHub Copilot
+
+The TypeSpec MCP Server provides assistance with authoring TypeSpec to generate MCP resource implementations. It can be used alone or with the [GitHub Copilot for Azure extension](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-azure-github-copilot) in VS Code.
+
+### Prerequisites
+1. Install either the stable or Insiders release of VS Code:
+   * [Stable release](https://code.visualstudio.com/download)
+   * [Insiders release](https://code.visualstudio.com/insiders)
+2. Install the [GitHub Copilot](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot) and [GitHub Copilot Chat](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot-chat) extensions
+3. Install [Node.js](https://nodejs.org/en/download) 22 or later
+   * Ensure `node` and `npm` are in your path
+4. Open VS Code in an empty folder
+
+### Installation
+
+#### One-Click Install
+
+Click one of these buttons to install the TypeSpec MCP Server for VS Code or VS Code Insiders.
+
+[![Install with NPX in VS Code](https://img.shields.io/badge/VS_Code-Install_TypeSpec_MCP_Server-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=TypeSpec%20MCP%20Server&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22mcp-server-typespec%40latest%22%5D%7D) [![Install with NPX in VS Code Insiders](https://img.shields.io/badge/VS_Code_Insiders-Install_TypeSpec_MCP_Server-24bfa5?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=TypeSpec%20MCP%20Server&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22mcp-server-typespec%40latest%22%5D%7D&quality=insiders)
+
+
+Once you've installed the TypeSpec MCP Server, make sure you select GitHub Copilot Agent Mode and refresh the tools list. To learn more about Agent Mode, visit the [VS Code Documentation](https://code.visualstudio.com/docs/copilot/chat/chat-agent-mode).
+
+#### Manual Install
+
+For a step-by-step installation, follow these instructions:
+
+1. Add `.vscode/mcp.json`:
+```json
+{
+  "servers": {
+    "TypeSpec MCP Server": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-server-typespec@latest",
+      ]
+    }
+  }
+}
+```
+
+## Test the TypeSpec MCP Server
+
+1. Open GitHub Copilot in VS Code and [switch to Agent mode](https://code.visualstudio.com/docs/copilot/chat/chat-agent-mode)
+2. You should see the TypeCpec MCP Server in the list of tools
+3. Try a prompt that tells the agent to use a TypeSpec MCP Server, such as "init" to scaffold a new project.
+
+
+## Troubleshooting
+
+See [Troubleshooting guide](https://github.com/bterlson/typespec-mcp/blob/main/TROUBLESHOOTING.md) for help with common issues and logging.
+
+## Contributing
+
+We welcome contributions to the TypeSpec MCP Server! Whether you're fixing bugs, adding new features, or improving documentation, your contributions are welcome.
+
+Please read our [Contributing Guide](https://github.com/bterlson/typespec-mcp/blob/main/CONTRIBUTING.md) for more information on how to contribute.
+
+## Code of Conduct
+
+This project has adopted the
+[Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+For more information, see the
+[Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/)
+or contact [opencode@microsoft.com](mailto:opencode@microsoft.com)
+with any additional questions or comments.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The TypeSpec MCP Server implements the [MCP specification](https://modelcontextp
 Currently this repo contains the following packages:
 
 - [mcp-server-typespec](https://github.com/bterlson/typespec-mcp/tree/main/packages/mcp-server-typespec) - an MCP server which assists in developing MCP extensions using TypeSpec.
-- [typespec-mcp](https://github.com/bterlson/typespec-mcp/tree/main/packages/typespec-mcp) - a TypeSpec library that provides a `tool` decorator.
+- [typespec-mcp](https://github.com/bterlson/typespec-mcp/tree/main/packages/typespec-mcp) - a TypeSpec library for describing MCP servers, for example the `@tool` decorator.
 - [typespec-mcp-server-js](https://github.com/bterlson/typespec-mcp/tree/main/packages/typespec-mcp-server-js) - A TypeSpec emitter that generates a server implementation in JavaScript for an MCP tool.
 - [typespec-mcp-http-server-js](https://github.com/bterlson/typespec-mcp/tree/main/packages/typespec-mcp-http-server-js) - A TypeSpec emitter that generates a server implementation in JavaScript for calling a remote REST API.
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The TypeSpec MCP Server requires Node.js to install and run the server. If you d
 
 ### VS Code + GitHub Copilot
 
-The TypeSpec MCP Server provides assistance with authoring TypeSpec to generate MCP resource implementations. It can be used alone or with the [GitHub Copilot for Azure extension](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-azure-github-copilot) in VS Code.
+The TypeSpec MCP Server provides assistance with authoring TypeSpec to generate MCP resource implementations. It can be used alone or with the [TypeSpec VS Code extension](https://typespec.io/docs/introduction/editor/vscode/) in VS Code.
 
 ### Prerequisites
 1. Install either the stable or Insiders release of VS Code:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Install with NPX in VS Code](https://img.shields.io/badge/VS_Code-Install_TypeSpec_MCP_Server-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=TypeSpec%20MCP%20Server&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22mcp-server-typespec%40latest%22%5D%7D) [![Install with NPX in VS Code Insiders](https://img.shields.io/badge/VS_Code_Insiders-Install_TypeSpec_MCP_Server-24bfa5?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=TypeSpec%20MCP%20Server&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22mcp-server-typespec%40latest%22%5D%7D&quality=insiders)
 
-The TypeSpec MCP Server implements the [MCP specification](https://modelcontextprotocol.io) to enable you to quickly build out your own MCP servers powered by [TypeSpec](https://typespec.io/).  We will also enable you to build REST APIs and other protocols supported by TypeSpec, though this is work in progress.
+The TypeSpec MCP Server implements the [MCP specification](https://modelcontextprotocol.io) to enable you to quickly build out your own MCP servers powered by [TypeSpec](https://typespec.io/). We will also enable you to build REST APIs and other protocols supported by TypeSpec, though this is work in progress.
 
 > Please note that this project is in Public Preview and implementation may significantly change prior to our General Availability.
 
@@ -26,7 +26,6 @@ The TypeSpec MCP Server provides the following tools:
 - `compile` - Runs tsp compile to generate emitter assets
 - `build` - Executes `npm run build` in the current project.
 
-
 ## Getting Started
 
 The TypeSpec MCP Server requires Node.js to install and run the server. If you don't have it installed, follow the instructions [here](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm).
@@ -36,12 +35,13 @@ The TypeSpec MCP Server requires Node.js to install and run the server. If you d
 The TypeSpec MCP Server provides assistance with authoring TypeSpec to generate MCP resource implementations. It can be used alone or with the [TypeSpec VS Code extension](https://typespec.io/docs/introduction/editor/vscode/) in VS Code.
 
 ### Prerequisites
+
 1. Install either the stable or Insiders release of VS Code:
-   * [Stable release](https://code.visualstudio.com/download)
-   * [Insiders release](https://code.visualstudio.com/insiders)
+   - [Stable release](https://code.visualstudio.com/download)
+   - [Insiders release](https://code.visualstudio.com/insiders)
 2. Install the [GitHub Copilot](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot) and [GitHub Copilot Chat](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot-chat) extensions
-3. Install [Node.js](https://nodejs.org/en/download) 22 or later
-   * Ensure `node` and `npm` are in your path
+3. Install [Node.js](https://nodejs.org/en/download) 20 or later
+   - Ensure `node` and `npm` are in your path
 4. Open VS Code in an empty folder
 
 ### Installation
@@ -52,7 +52,6 @@ Click one of these buttons to install the TypeSpec MCP Server for VS Code or VS 
 
 [![Install with NPX in VS Code](https://img.shields.io/badge/VS_Code-Install_TypeSpec_MCP_Server-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=TypeSpec%20MCP%20Server&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22mcp-server-typespec%40latest%22%5D%7D) [![Install with NPX in VS Code Insiders](https://img.shields.io/badge/VS_Code_Insiders-Install_TypeSpec_MCP_Server-24bfa5?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=TypeSpec%20MCP%20Server&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22mcp-server-typespec%40latest%22%5D%7D&quality=insiders)
 
-
 Once you've installed the TypeSpec MCP Server, make sure you select GitHub Copilot Agent Mode and refresh the tools list. To learn more about Agent Mode, visit the [VS Code Documentation](https://code.visualstudio.com/docs/copilot/chat/chat-agent-mode).
 
 #### Manual Install
@@ -60,15 +59,13 @@ Once you've installed the TypeSpec MCP Server, make sure you select GitHub Copil
 For a step-by-step installation, follow these instructions:
 
 1. Add `.vscode/mcp.json`:
+
 ```json
 {
   "servers": {
     "TypeSpec MCP Server": {
       "command": "npx",
-      "args": [
-        "-y",
-        "mcp-server-typespec@latest",
-      ]
+      "args": ["-y", "mcp-server-typespec@latest"]
     }
   }
 }
@@ -79,7 +76,6 @@ For a step-by-step installation, follow these instructions:
 1. Open GitHub Copilot in VS Code and [switch to Agent mode](https://code.visualstudio.com/docs/copilot/chat/chat-agent-mode)
 2. You should see the TypeCpec MCP Server in the list of tools
 3. Try a prompt that tells the agent to use a TypeSpec MCP Server, such as "init" to scaffold a new project.
-
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Install with NPX in VS Code](https://img.shields.io/badge/VS_Code-Install_TypeSpec_MCP_Server-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=TypeSpec%20MCP%20Server&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22mcp-server-typespec%40latest%22%5D%7D) [![Install with NPX in VS Code Insiders](https://img.shields.io/badge/VS_Code_Insiders-Install_TypeSpec_MCP_Server-24bfa5?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=TypeSpec%20MCP%20Server&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22mcp-server-typespec%40latest%22%5D%7D&quality=insiders)
 
-The TypeSpec MCP Server implements the [MCP specification](https://modelcontextprotocol.io) to enable you to quickly build out your own MCP extensions powered by [TypeSpec](https://typespec.io/)
+The TypeSpec MCP Server implements the [MCP specification](https://modelcontextprotocol.io) to enable you to quickly build out your own MCP servers powered by [TypeSpec](https://typespec.io/).  We will also enable you to build REST APIs and other protocols supported by TypeSpec, though this is work in progress.
 
 > Please note that this project is in Public Preview and implementation may significantly change prior to our General Availability.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,41 @@
+<!-- BEGIN MICROSOFT SECURITY.MD V0.0.9 BLOCK -->
+
+## Security
+
+Microsoft takes the security of our software products and services seriously, which includes all source code repositories managed through our GitHub organizations, which include [Microsoft](https://github.com/Microsoft), [Azure](https://github.com/Azure), [DotNet](https://github.com/dotnet), [AspNet](https://github.com/aspnet) and [Xamarin](https://github.com/xamarin).
+
+If you believe you have found a security vulnerability in any Microsoft-owned repository that meets [Microsoft's definition of a security vulnerability](https://aka.ms/security.md/definition), please report it to us as described below.
+
+## Reporting Security Issues
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+Instead, please report them to the Microsoft Security Response Center (MSRC) at [https://msrc.microsoft.com/create-report](https://aka.ms/security.md/msrc/create-report).
+
+If you prefer to submit without logging in, send email to [secure@microsoft.com](mailto:secure@microsoft.com).  If possible, encrypt your message with our PGP key; please download it from the [Microsoft Security Response Center PGP Key page](https://aka.ms/security.md/msrc/pgp).
+
+You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Additional information can be found at [microsoft.com/msrc](https://www.microsoft.com/msrc). 
+
+Please include the requested information listed below (as much as you can provide) to help us better understand the nature and scope of the possible issue:
+
+  * Type of issue (e.g. buffer overflow, SQL injection, cross-site scripting, etc.)
+  * Full paths of source file(s) related to the manifestation of the issue
+  * The location of the affected source code (tag/branch/commit or direct URL)
+  * Any special configuration required to reproduce the issue
+  * Step-by-step instructions to reproduce the issue
+  * Proof-of-concept or exploit code (if possible)
+  * Impact of the issue, including how an attacker might exploit the issue
+
+This information will help us triage your report more quickly.
+
+If you are reporting for a bug bounty, more complete reports can contribute to a higher bounty award. Please visit our [Microsoft Bug Bounty Program](https://aka.ms/security.md/msrc/bounty) page for more details about our active programs.
+
+## Preferred Languages
+
+We prefer all communications to be in English.
+
+## Policy
+
+Microsoft follows the principle of [Coordinated Vulnerability Disclosure](https://aka.ms/security.md/cvd).
+
+<!-- END MICROSOFT SECURITY.MD BLOCK -->

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,19 +12,19 @@ If you believe you have found a security vulnerability in any Microsoft-owned re
 
 Instead, please report them to the Microsoft Security Response Center (MSRC) at [https://msrc.microsoft.com/create-report](https://aka.ms/security.md/msrc/create-report).
 
-If you prefer to submit without logging in, send email to [secure@microsoft.com](mailto:secure@microsoft.com).  If possible, encrypt your message with our PGP key; please download it from the [Microsoft Security Response Center PGP Key page](https://aka.ms/security.md/msrc/pgp).
+If you prefer to submit without logging in, send email to [secure@microsoft.com](mailto:secure@microsoft.com). If possible, encrypt your message with our PGP key; please download it from the [Microsoft Security Response Center PGP Key page](https://aka.ms/security.md/msrc/pgp).
 
-You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Additional information can be found at [microsoft.com/msrc](https://www.microsoft.com/msrc). 
+You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Additional information can be found at [microsoft.com/msrc](https://www.microsoft.com/msrc).
 
 Please include the requested information listed below (as much as you can provide) to help us better understand the nature and scope of the possible issue:
 
-  * Type of issue (e.g. buffer overflow, SQL injection, cross-site scripting, etc.)
-  * Full paths of source file(s) related to the manifestation of the issue
-  * The location of the affected source code (tag/branch/commit or direct URL)
-  * Any special configuration required to reproduce the issue
-  * Step-by-step instructions to reproduce the issue
-  * Proof-of-concept or exploit code (if possible)
-  * Impact of the issue, including how an attacker might exploit the issue
+- Type of issue (e.g. buffer overflow, SQL injection, cross-site scripting, etc.)
+- Full paths of source file(s) related to the manifestation of the issue
+- The location of the affected source code (tag/branch/commit or direct URL)
+- Any special configuration required to reproduce the issue
+- Step-by-step instructions to reproduce the issue
+- Proof-of-concept or exploit code (if possible)
+- Impact of the issue, including how an attacker might exploit the issue
 
 This information will help us triage your report more quickly.
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,0 +1,2 @@
+# Troubleshooting
+

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,2 +1,1 @@
 # Troubleshooting
-

--- a/package.json
+++ b/package.json
@@ -20,5 +20,5 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC"
+  "license": "MIT"
 }

--- a/packages/mcp-server-typespec/LICENSE
+++ b/packages/mcp-server-typespec/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright 2025 (c) Microsoft Corporation.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE

--- a/packages/mcp-server-typespec/README.md
+++ b/packages/mcp-server-typespec/README.md
@@ -1,0 +1,62 @@
+# mcp-server-typespec
+
+
+## Overview
+
+This package provides an MCP server which assists in developing MCP extensions using TypeSpec.
+
+### Installation
+
+#### One-Click Install
+
+Click one of these buttons to install the TypeSpec MCP Server for VS Code or VS Code Insiders.
+
+[![Install with NPX in VS Code](https://img.shields.io/badge/VS_Code-Install_TypeSpec_MCP_Server-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=TypeSpec%20MCP%20Server&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22mcp-server-typespec%40latest%22%5D%7D) [![Install with NPX in VS Code Insiders](https://img.shields.io/badge/VS_Code_Insiders-Install_TypeSpec_MCP_Server-24bfa5?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=TypeSpec%20MCP%20Server&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22mcp-server-typespec%40latest%22%5D%7D&quality=insiders)
+
+
+Once you've installed the TypeSpec MCP Server, make sure you select GitHub Copilot Agent Mode and refresh the tools list. To learn more about Agent Mode, visit the [VS Code Documentation](https://code.visualstudio.com/docs/copilot/chat/chat-agent-mode).
+
+#### Manual Install
+
+For a step-by-step installation, follow these instructions:
+
+1. Add `.vscode/mcp.json`:
+```json
+{
+  "servers": {
+    "TypeSpec MCP Server": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-server-typespec@latest",
+      ]
+    }
+  }
+}
+```
+
+## Test the TypeSpec MCP Server
+
+1. Open GitHub Copilot in VS Code and [switch to Agent mode](https://code.visualstudio.com/docs/copilot/chat/chat-agent-mode)
+2. You should see the TypeCpec MCP Server in the list of tools
+3. Try a prompt that tells the agent to use a TypeSpec MCP Server, such as "init" to scaffold a new project.
+
+
+## Troubleshooting
+
+See [Troubleshooting guide](https://github.com/bterlson/typespec-mcp/blob/main/TROUBLESHOOTING.md) for help with common issues and logging.
+
+## Contributing
+
+We welcome contributions to the TypeSpec MCP Server! Whether you're fixing bugs, adding new features, or improving documentation, your contributions are welcome.
+
+Please read our [Contributing Guide](https://github.com/bterlson/typespec-mcp/blob/main/CONTRIBUTING.md) for more information on how to contribute.
+
+## Code of Conduct
+
+This project has adopted the
+[Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+For more information, see the
+[Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/)
+or contact [opencode@microsoft.com](mailto:opencode@microsoft.com)
+with any additional questions or comments.

--- a/packages/mcp-server-typespec/README.md
+++ b/packages/mcp-server-typespec/README.md
@@ -1,6 +1,5 @@
 # mcp-server-typespec
 
-
 ## Overview
 
 This package provides an MCP server which assists in developing MCP extensions using TypeSpec.
@@ -13,7 +12,6 @@ Click one of these buttons to install the TypeSpec MCP Server for VS Code or VS 
 
 [![Install with NPX in VS Code](https://img.shields.io/badge/VS_Code-Install_TypeSpec_MCP_Server-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=TypeSpec%20MCP%20Server&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22mcp-server-typespec%40latest%22%5D%7D) [![Install with NPX in VS Code Insiders](https://img.shields.io/badge/VS_Code_Insiders-Install_TypeSpec_MCP_Server-24bfa5?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=TypeSpec%20MCP%20Server&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22mcp-server-typespec%40latest%22%5D%7D&quality=insiders)
 
-
 Once you've installed the TypeSpec MCP Server, make sure you select GitHub Copilot Agent Mode and refresh the tools list. To learn more about Agent Mode, visit the [VS Code Documentation](https://code.visualstudio.com/docs/copilot/chat/chat-agent-mode).
 
 #### Manual Install
@@ -21,15 +19,13 @@ Once you've installed the TypeSpec MCP Server, make sure you select GitHub Copil
 For a step-by-step installation, follow these instructions:
 
 1. Add `.vscode/mcp.json`:
+
 ```json
 {
   "servers": {
     "TypeSpec MCP Server": {
       "command": "npx",
-      "args": [
-        "-y",
-        "mcp-server-typespec@latest",
-      ]
+      "args": ["-y", "mcp-server-typespec@latest"]
     }
   }
 }
@@ -40,7 +36,6 @@ For a step-by-step installation, follow these instructions:
 1. Open GitHub Copilot in VS Code and [switch to Agent mode](https://code.visualstudio.com/docs/copilot/chat/chat-agent-mode)
 2. You should see the TypeCpec MCP Server in the list of tools
 3. Try a prompt that tells the agent to use a TypeSpec MCP Server, such as "init" to scaffold a new project.
-
 
 ## Troubleshooting
 

--- a/packages/mcp-server-typespec/package.json
+++ b/packages/mcp-server-typespec/package.json
@@ -30,6 +30,6 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "type": "module"
 }

--- a/packages/typespec-mcp-http-server-js/LICENSE
+++ b/packages/typespec-mcp-http-server-js/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright 2025 (c) Microsoft Corporation.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE

--- a/packages/typespec-mcp-http-server-js/README.md
+++ b/packages/typespec-mcp-http-server-js/README.md
@@ -1,0 +1,25 @@
+# typespec-mcp-http-server-js
+
+
+## Overview
+
+This package is a TypeSpec emitter that generates a server implementation in JavaScript for calling a remote REST API.
+
+## Troubleshooting
+
+See [Troubleshooting guide](https://github.com/bterlson/typespec-mcp/blob/main/TROUBLESHOOTING.md) for help with common issues and logging.
+
+## Contributing
+
+We welcome contributions to the TypeSpec MCP Server! Whether you're fixing bugs, adding new features, or improving documentation, your contributions are welcome.
+
+Please read our [Contributing Guide](https://github.com/bterlson/typespec-mcp/blob/main/CONTRIBUTING.md) for more information on how to contribute.
+
+## Code of Conduct
+
+This project has adopted the
+[Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+For more information, see the
+[Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/)
+or contact [opencode@microsoft.com](mailto:opencode@microsoft.com)
+with any additional questions or comments.

--- a/packages/typespec-mcp-http-server-js/README.md
+++ b/packages/typespec-mcp-http-server-js/README.md
@@ -1,6 +1,5 @@
 # typespec-mcp-http-server-js
 
-
 ## Overview
 
 This package is a TypeSpec emitter that generates a server implementation in JavaScript for calling a remote REST API.

--- a/packages/typespec-mcp-http-server-js/package.json
+++ b/packages/typespec-mcp-http-server-js/package.json
@@ -32,7 +32,7 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "type": "module",
   "devDependencies": {
     "@alloy-js/cli": "catalog:",

--- a/packages/typespec-mcp-server-js/LICENSE
+++ b/packages/typespec-mcp-server-js/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright 2025 (c) Microsoft Corporation.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE

--- a/packages/typespec-mcp-server-js/README.md
+++ b/packages/typespec-mcp-server-js/README.md
@@ -1,0 +1,25 @@
+# typespec-mcp-server-js
+
+
+## Overview
+
+This package is a TypeSpec emitter that generates a server implementation in JavaScript for an MCP tool.
+
+## Troubleshooting
+
+See [Troubleshooting guide](https://github.com/bterlson/typespec-mcp/blob/main/TROUBLESHOOTING.md) for help with common issues and logging.
+
+## Contributing
+
+We welcome contributions to the TypeSpec MCP Server! Whether you're fixing bugs, adding new features, or improving documentation, your contributions are welcome.
+
+Please read our [Contributing Guide](https://github.com/bterlson/typespec-mcp/blob/main/CONTRIBUTING.md) for more information on how to contribute.
+
+## Code of Conduct
+
+This project has adopted the
+[Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+For more information, see the
+[Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/)
+or contact [opencode@microsoft.com](mailto:opencode@microsoft.com)
+with any additional questions or comments.

--- a/packages/typespec-mcp-server-js/README.md
+++ b/packages/typespec-mcp-server-js/README.md
@@ -1,6 +1,5 @@
 # typespec-mcp-server-js
 
-
 ## Overview
 
 This package is a TypeSpec emitter that generates a server implementation in JavaScript for an MCP tool.

--- a/packages/typespec-mcp-server-js/package.json
+++ b/packages/typespec-mcp-server-js/package.json
@@ -33,7 +33,7 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "type": "module",
   "devDependencies": {
     "@alloy-js/cli": "catalog:",

--- a/packages/typespec-mcp/LICENSE
+++ b/packages/typespec-mcp/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright 2025 (c) Microsoft Corporation.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE

--- a/packages/typespec-mcp/README.md
+++ b/packages/typespec-mcp/README.md
@@ -1,6 +1,5 @@
 # typespec-mcp
 
-
 ## Overview
 
 This package is a TypeSpec library that provides a `tool` decorator. Support for Prompts and Resources is still in active development.

--- a/packages/typespec-mcp/README.md
+++ b/packages/typespec-mcp/README.md
@@ -1,0 +1,25 @@
+# typespec-mcp
+
+
+## Overview
+
+This package is a TypeSpec library that provides a `tool` decorator. Support for Prompts and Resources is still in active development.
+
+## Troubleshooting
+
+See [Troubleshooting guide](https://github.com/bterlson/typespec-mcp/blob/main/TROUBLESHOOTING.md) for help with common issues and logging.
+
+## Contributing
+
+We welcome contributions to the TypeSpec MCP Server! Whether you're fixing bugs, adding new features, or improving documentation, your contributions are welcome.
+
+Please read our [Contributing Guide](https://github.com/bterlson/typespec-mcp/blob/main/CONTRIBUTING.md) for more information on how to contribute.
+
+## Code of Conduct
+
+This project has adopted the
+[Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+For more information, see the
+[Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/)
+or contact [opencode@microsoft.com](mailto:opencode@microsoft.com)
+with any additional questions or comments.

--- a/packages/typespec-mcp/package.json
+++ b/packages/typespec-mcp/package.json
@@ -30,7 +30,7 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "type": "module",
   "devDependencies": {
     "@types/node": "catalog:",


### PR DESCRIPTION
This PR:

- Scaffolds out a top-level README and the bare bones beginning of per-package READMEs.
- Adds required files like CONTRIBUTING.md and SECURITY.md
- Adds MIT license files to each package

Appreciate any corrections/improvements to the content as well as ideas for other content we need to add (troubleshooting steps, usage examples for the TSP libraries/emitters, suggested prompts, etc.)

